### PR TITLE
apt-get update before OpenCV install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM google/appengine-python27
-RUN apt-get install -y python-opencv
+RUN apt-get update && apt-get install -y python-opencv
 
 ADD . /app


### PR DESCRIPTION
I couldn't get the Docker container to build until I added the line for apt-get update before the OpenCV installation. 

```
$ docker --version
Docker version 1.4.1, build 5bc2ff8
```

Error with the existing code:
```
ERROR: Error building docker image main-presence-762.solver.opencv
ERROR: Build Error: The command [/bin/sh -c apt-get install -y python-opencv] returned a non-zero code: 100.
ERROR: Full Image Build Log:
 ---> 42d46fb3a9cd
Step 1 : RUN apt-get install -y python-opencv
 ---> Running in e308da4bff54
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package python-opencv
```